### PR TITLE
fix: replace kkinstagram.com with kksave.com

### DIFF
--- a/internal/tghandler/messages.go
+++ b/internal/tghandler/messages.go
@@ -576,8 +576,8 @@ func (h *Handler) fixURLPreview(update tgbotapi.Update) {
 		}
 		if strings.Contains(url, "https://www.instagram.com") || strings.Contains(url, "https://instagram.com") {
 			h.sendAction(update, tgbotapi.ChatTyping)
-			url = strings.ReplaceAll(url, "https://www.instagram.com", "https://kkinstagram.com")
-			url = strings.ReplaceAll(url, "https://instagram.com", "https://kkinstagram.com")
+			url = strings.ReplaceAll(url, "https://www.instagram.com", "https://kksave.com")
+			url = strings.ReplaceAll(url, "https://instagram.com", "https://kksave.com")
 
 			message := buildFixedMessage(update.Message.From.UserName, url, caption)
 			h.sendMessage(update, message)


### PR DESCRIPTION
`kkinstagram.com` is no longer working as an Instagram embed proxy. This replaces it with `kksave.com`, which is the current working alternative for embedding Instagram reels directly in Telegram.