### PR TITLE
Use self-hosted InstaFix at jeff.shaba.lol

### DIFF
--- a/internal/tghandler/messages.go
+++ b/internal/tghandler/messages.go
@@ -576,8 +576,8 @@ func (h *Handler) fixURLPreview(update tgbotapi.Update) {
 		}
 		if strings.Contains(url, "https://www.instagram.com") || strings.Contains(url, "https://instagram.com") {
 			h.sendAction(update, tgbotapi.ChatTyping)
-			url = strings.ReplaceAll(url, "https://www.instagram.com", "https://eeinstagram.com")
-			url = strings.ReplaceAll(url, "https://instagram.com", "https://eeinstagram.com")
+			url = strings.ReplaceAll(url, "https://www.instagram.com", "https://jeff.shaba.lol")
+			url = strings.ReplaceAll(url, "https://instagram.com", "https://jeff.shaba.lol")
 
 			message := buildFixedMessage(update.Message.From.UserName, url, caption)
 			h.sendMessage(update, message)

--- a/internal/tghandler/messages.go
+++ b/internal/tghandler/messages.go
@@ -576,8 +576,8 @@ func (h *Handler) fixURLPreview(update tgbotapi.Update) {
 		}
 		if strings.Contains(url, "https://www.instagram.com") || strings.Contains(url, "https://instagram.com") {
 			h.sendAction(update, tgbotapi.ChatTyping)
-			url = strings.ReplaceAll(url, "https://www.instagram.com", "https://kksave.com")
-			url = strings.ReplaceAll(url, "https://instagram.com", "https://kksave.com")
+			url = strings.ReplaceAll(url, "https://www.instagram.com", "https://eeinstagram.com")
+			url = strings.ReplaceAll(url, "https://instagram.com", "https://eeinstagram.com")
 
 			message := buildFixedMessage(update.Message.From.UserName, url, caption)
 			h.sendMessage(update, message)


### PR DESCRIPTION
## Summary
- Switch Instagram embed domain from `eeinstagram.com` to a self-hosted InstaFix instance at `jeff.shaba.lol`

## Test plan
- [ ] Send an Instagram link in Telegram and verify it gets rewritten to `jeff.shaba.lol`
- [ ] Confirm the embed loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)