### PR TITLE
fix: update Instagram proxy domain to kksav.com

### DIFF
--- a/internal/tghandler/messages.go
+++ b/internal/tghandler/messages.go
@@ -576,8 +576,8 @@ func (h *Handler) fixURLPreview(update tgbotapi.Update) {
 		}
 		if strings.Contains(url, "https://www.instagram.com") || strings.Contains(url, "https://instagram.com") {
 			h.sendAction(update, tgbotapi.ChatTyping)
-			url = strings.ReplaceAll(url, "https://www.instagram.com", "https://jeff.shaba.lol")
-			url = strings.ReplaceAll(url, "https://instagram.com", "https://jeff.shaba.lol")
+			url = strings.ReplaceAll(url, "https://www.instagram.com", "https://kksav.com")
+			url = strings.ReplaceAll(url, "https://instagram.com", "https://kksav.com")
 
 			message := buildFixedMessage(update.Message.From.UserName, url, caption)
 			h.sendMessage(update, message)


### PR DESCRIPTION
## Summary
- Replace `jeff.shaba.lol` with `kksav.com` as the proxy domain when rewriting Instagram links

🤖 Generated with [Claude Code](https://claude.com/claude-code)