### PR TITLE
refactor: move model definitions to config file and update to latest versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/shabablinchikow/nafanya-bot
 go 1.24
 
 require (
-	cloud.google.com/go/vertexai v0.13.3
+	cloud.google.com/go/vertexai v0.15.0
 	github.com/getsentry/sentry-go v0.32.0
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/lib/pq v1.10.9
-	github.com/sashabaranov/go-openai v1.40.0
+	github.com/sashabaranov/go-openai v1.41.0
 	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c
 	google.golang.org/api v0.233.0
 	gorm.io/driver/postgres v1.5.11
@@ -50,7 +50,7 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
-	google.golang.org/genai v1.48.0 // indirect
+	google.golang.org/genai v1.50.0 // indirect
 	google.golang.org/genproto v0.0.0-20241118233622-e639e219e697 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250218202821-56aae31c358a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250505200425-f936aa4a68b2 // indirect

--- a/internal/aihandler/ai.go
+++ b/internal/aihandler/ai.go
@@ -8,6 +8,7 @@ import (
 
 	"cloud.google.com/go/vertexai/genai"
 	"github.com/getsentry/sentry-go"
+	"github.com/shabablinchikow/nafanya-bot/internal/cfg"
 	"github.com/sashabaranov/go-openai"
 	genaisdk "google.golang.org/genai"
 	"mvdan.cc/xurls/v2"
@@ -31,11 +32,11 @@ func NewHandler(oai *openai.Client, googleAI *genai.Client, deep *openai.Client,
 
 func (h *Handler) GetPromptResponse(prompt string, userInput string, model string, maxTokens int) (string, error) {
 	switch model {
-	case "oai":
+	case string(cfg.AIModelOAI):
 		return h.GetPromptResponseOAI(prompt, userInput, maxTokens)
-	case "deepseek":
+	case string(cfg.AIModelDeepSeek):
 		return h.GetPromptResponseDS(prompt, userInput, maxTokens)
-	case "google":
+	case string(cfg.AIModelGoogle):
 		return h.GetPromptResponseGoogle(prompt, userInput, maxTokens)
 	}
 
@@ -43,11 +44,11 @@ func (h *Handler) GetPromptResponse(prompt string, userInput string, model strin
 }
 
 func (h *Handler) GetPromptResponseOAI(prompt string, userInput string, maxTokens int) (string, error) {
-	return h.GetPromptResponseOAICommon(h.aiOAI, prompt, userInput, maxTokens, "gpt-5")
+	return h.GetPromptResponseOAICommon(h.aiOAI, prompt, userInput, maxTokens, cfg.GetAIModelBackendName(cfg.AIModelOAI))
 }
 
 func (h *Handler) GetPromptResponseDS(prompt string, userInput string, maxTokens int) (string, error) {
-	return h.GetPromptResponseOAICommon(h.deepSeek, prompt, userInput, maxTokens, "deepseek-chat")
+	return h.GetPromptResponseOAICommon(h.deepSeek, prompt, userInput, maxTokens, cfg.GetAIModelBackendName(cfg.AIModelDeepSeek))
 }
 
 func (h *Handler) GetPromptResponseOAICommon(client *openai.Client, prompt string, userInput string, maxTokens int, model string) (string, error) {
@@ -93,7 +94,6 @@ func (h *Handler) GetPromptResponseGoogle(prompt string, userInput string, maxTo
 	return h.getPromptResponseVertexAI(prompt, userInput, maxTokens)
 }
 
-const geminiModel = "gemini-3.1-pro-preview"
 const geminiRetries = 3
 
 // extractYouTubeURLs finds YouTube URLs in userInput, returns them and the cleaned text.
@@ -135,7 +135,7 @@ func (h *Handler) getPromptResponseGeminiDirect(prompt string, userInput string,
 	for i := range geminiRetries {
 		resp, err := h.geminiDirect.Models.GenerateContent(
 			context.Background(),
-			geminiModel,
+			cfg.GetAIModelBackendName(cfg.AIModelGoogle),
 			contents,
 			cfg,
 		)
@@ -151,7 +151,7 @@ func (h *Handler) getPromptResponseGeminiDirect(prompt string, userInput string,
 
 
 func (h *Handler) getPromptResponseVertexAI(prompt string, userInput string, maxTokens int) (string, error) {
-	model := h.aiGoogle.GenerativeModel("gemini-2.0-flash-001")
+	model := h.aiGoogle.GenerativeModel(cfg.VertexAIModel())
 
 	model.SafetySettings = []*genai.SafetySetting{
 		{Category: genai.HarmCategoryHarassment, Threshold: genai.HarmBlockOnlyHigh},
@@ -195,7 +195,7 @@ func (h *Handler) GetImageFromPromptBanana(prompt string) ([]byte, string, error
 
 	resp, err := h.geminiDirect.Models.GenerateImages(
 		context.Background(),
-		"imagen-4.0-fast-generate-001",
+		cfg.GetImageModelBackendName(cfg.ImageModelBanana),
 		prompt,
 		&genaisdk.GenerateImagesConfig{
 			NumberOfImages: 1,
@@ -223,7 +223,7 @@ func (h *Handler) GetImageFromPrompt(prompt string) (string, error) {
 			Size:           openai.CreateImageSize1792x1024,
 			ResponseFormat: openai.CreateImageResponseFormatURL,
 			Quality:        openai.CreateImageQualityHD,
-			Model:          "gpt-image-1.5",
+			Model:          cfg.GetImageModelBackendName(cfg.ImageModelOAI),
 		})
 	if err != nil {
 		sentry.CaptureException(err)

--- a/internal/aihandler/ai.go
+++ b/internal/aihandler/ai.go
@@ -32,11 +32,11 @@ func NewHandler(oai *openai.Client, googleAI *genai.Client, deep *openai.Client,
 
 func (h *Handler) GetPromptResponse(prompt string, userInput string, model string, maxTokens int) (string, error) {
 	switch model {
-	case string(cfg.AIModelOAI):
+	case string(cfg.AIModelGPT55):
 		return h.GetPromptResponseOAI(prompt, userInput, maxTokens)
-	case string(cfg.AIModelDeepSeek):
+	case string(cfg.AIModelDeepSeekV4):
 		return h.GetPromptResponseDS(prompt, userInput, maxTokens)
-	case string(cfg.AIModelGoogle):
+	case string(cfg.AIModelGemini35):
 		return h.GetPromptResponseGoogle(prompt, userInput, maxTokens)
 	}
 
@@ -44,11 +44,11 @@ func (h *Handler) GetPromptResponse(prompt string, userInput string, model strin
 }
 
 func (h *Handler) GetPromptResponseOAI(prompt string, userInput string, maxTokens int) (string, error) {
-	return h.GetPromptResponseOAICommon(h.aiOAI, prompt, userInput, maxTokens, cfg.GetAIModelBackendName(cfg.AIModelOAI))
+	return h.GetPromptResponseOAICommon(h.aiOAI, prompt, userInput, maxTokens, cfg.GetAIModelBackendName(cfg.AIModelGPT55))
 }
 
 func (h *Handler) GetPromptResponseDS(prompt string, userInput string, maxTokens int) (string, error) {
-	return h.GetPromptResponseOAICommon(h.deepSeek, prompt, userInput, maxTokens, cfg.GetAIModelBackendName(cfg.AIModelDeepSeek))
+	return h.GetPromptResponseOAICommon(h.deepSeek, prompt, userInput, maxTokens, cfg.GetAIModelBackendName(cfg.AIModelDeepSeekV4))
 }
 
 func (h *Handler) GetPromptResponseOAICommon(client *openai.Client, prompt string, userInput string, maxTokens int, model string) (string, error) {
@@ -135,7 +135,7 @@ func (h *Handler) getPromptResponseGeminiDirect(prompt string, userInput string,
 	for i := range geminiRetries {
 		resp, err := h.geminiDirect.Models.GenerateContent(
 			context.Background(),
-			cfg.GetAIModelBackendName(cfg.AIModelGoogle),
+			cfg.GetAIModelBackendName(cfg.AIModelGemini35),
 			contents,
 			cfg,
 		)
@@ -195,7 +195,7 @@ func (h *Handler) GetImageFromPromptBanana(prompt string) ([]byte, string, error
 
 	resp, err := h.geminiDirect.Models.GenerateImages(
 		context.Background(),
-		cfg.GetImageModelBackendName(cfg.ImageModelBanana),
+		cfg.GetImageModelBackendName(cfg.ImageModelGemini31),
 		prompt,
 		&genaisdk.GenerateImagesConfig{
 			NumberOfImages: 1,
@@ -223,7 +223,7 @@ func (h *Handler) GetImageFromPrompt(prompt string) (string, error) {
 			Size:           openai.CreateImageSize1792x1024,
 			ResponseFormat: openai.CreateImageResponseFormatURL,
 			Quality:        openai.CreateImageQualityHD,
-			Model:          cfg.GetImageModelBackendName(cfg.ImageModelOAI),
+			Model:          cfg.GetImageModelBackendName(cfg.ImageModelGPTImage2),
 		})
 	if err != nil {
 		sentry.CaptureException(err)

--- a/internal/cfg/models.go
+++ b/internal/cfg/models.go
@@ -6,21 +6,21 @@ package cfg
 type AIModel string
 
 const (
-	// AI Model identifiers (user-facing)
-	AIModelOAI      AIModel = "oai"
-	AIModelGoogle   AIModel = "google"
-	AIModelDeepSeek AIModel = "deepseek"
+	// AI Model identifiers (user-facing) - using actual model names
+	AIModelGPT55      AIModel = "gpt-5.5"
+	AIModelGemini35  AIModel = "gemini-3.5-flash"
+	AIModelDeepSeekV4 AIModel = "deepseek-v4-pro"
 )
 
 // GetAllAIModels returns all available AI model identifiers
 func GetAllAIModels() []AIModel {
-	return []AIModel{AIModelOAI, AIModelGoogle, AIModelDeepSeek}
+	return []AIModel{AIModelGPT55, AIModelGemini35, AIModelDeepSeekV4}
 }
 
 // IsValidAIModel checks if the given model string is a valid AI model
 func IsValidAIModel(model string) bool {
 	switch AIModel(model) {
-	case AIModelOAI, AIModelGoogle, AIModelDeepSeek:
+	case AIModelGPT55, AIModelGemini35, AIModelDeepSeekV4:
 		return true
 	default:
 		return false
@@ -28,39 +28,32 @@ func IsValidAIModel(model string) bool {
 }
 
 // GetAIModelBackendName returns the actual model name for the AI backend
+// For most models, the user-facing name is the same as the backend name.
 // Note: As of 2026-06-15, gemini-3.5-pro is not yet available as an API model.
 // The current Pro-family baseline is gemini-3.1-pro-preview.
 func GetAIModelBackendName(model AIModel) string {
-	switch model {
-	case AIModelOAI:
-		return "gpt-5.5"
-	case AIModelDeepSeek:
-		return "deepseek-v4-pro"
-	case AIModelGoogle:
-		return "gemini-3.5-flash"
-	default:
-		return ""
-	}
+	// User-facing names match backend names, so return as-is
+	return string(model)
 }
 
 // ImageModel represents the available image generation models
 type ImageModel string
 
 const (
-	// Image Model identifiers (user-facing)
-	ImageModelOAI    ImageModel = "oai"
-	ImageModelBanana ImageModel = "banana"
+	// Image Model identifiers (user-facing) - using actual model names
+	ImageModelGPTImage2    ImageModel = "gpt-image-2"
+	ImageModelGemini31    ImageModel = "gemini-3.1-flash-image"
 )
 
 // GetAllImageModels returns all available image model identifiers
 func GetAllImageModels() []ImageModel {
-	return []ImageModel{ImageModelOAI, ImageModelBanana}
+	return []ImageModel{ImageModelGPTImage2, ImageModelGemini31}
 }
 
 // IsValidImageModel checks if the given model string is a valid image model
 func IsValidImageModel(model string) bool {
 	switch ImageModel(model) {
-	case ImageModelOAI, ImageModelBanana:
+	case ImageModelGPTImage2, ImageModelGemini31:
 		return true
 	default:
 		return false
@@ -70,15 +63,10 @@ func IsValidImageModel(model string) bool {
 // GetImageModelBackendName returns the actual model name for the image backend
 // Note: The -preview suffixed image endpoints (gemini-3.1-flash-image-preview, gemini-3-pro-image-preview)
 // are deprecated and scheduled to shut down on 2026-06-25. Using GA strings instead.
+// For most models, the user-facing name is the same as the backend name.
 func GetImageModelBackendName(model ImageModel) string {
-	switch model {
-	case ImageModelOAI:
-		return "gpt-image-2"
-	case ImageModelBanana:
-		return "gemini-3.1-flash-image"
-	default:
-		return ""
-	}
+	// User-facing names match backend names, so return as-is
+	return string(model)
 }
 
 // VertexAIModel returns the Vertex AI model name for Google
@@ -89,10 +77,10 @@ func VertexAIModel() string {
 
 // DefaultAIModel returns the default AI model
 func DefaultAIModel() AIModel {
-	return AIModelOAI
+	return AIModelGPT55
 }
 
 // DefaultImageModel returns the default image model
 func DefaultImageModel() ImageModel {
-	return ImageModelOAI
+	return ImageModelGPTImage2
 }

--- a/internal/cfg/models.go
+++ b/internal/cfg/models.go
@@ -1,0 +1,93 @@
+package cfg
+
+// Model definitions for AI and Image generation
+
+// AIModel represents the available AI models for text generation
+type AIModel string
+
+const (
+	// AI Model identifiers (user-facing)
+	AIModelOAI      AIModel = "oai"
+	AIModelGoogle   AIModel = "google"
+	AIModelDeepSeek AIModel = "deepseek"
+)
+
+// GetAllAIModels returns all available AI model identifiers
+func GetAllAIModels() []AIModel {
+	return []AIModel{AIModelOAI, AIModelGoogle, AIModelDeepSeek}
+}
+
+// IsValidAIModel checks if the given model string is a valid AI model
+func IsValidAIModel(model string) bool {
+	switch AIModel(model) {
+	case AIModelOAI, AIModelGoogle, AIModelDeepSeek:
+		return true
+	default:
+		return false
+	}
+}
+
+// GetAIModelBackendName returns the actual model name for the AI backend
+func GetAIModelBackendName(model AIModel) string {
+	switch model {
+	case AIModelOAI:
+		return "gpt-5"
+	case AIModelDeepSeek:
+		return "deepseek-chat"
+	case AIModelGoogle:
+		return "gemini-3.1-pro-preview"
+	default:
+		return ""
+	}
+}
+
+// ImageModel represents the available image generation models
+type ImageModel string
+
+const (
+	// Image Model identifiers (user-facing)
+	ImageModelOAI    ImageModel = "oai"
+	ImageModelBanana ImageModel = "banana"
+)
+
+// GetAllImageModels returns all available image model identifiers
+func GetAllImageModels() []ImageModel {
+	return []ImageModel{ImageModelOAI, ImageModelBanana}
+}
+
+// IsValidImageModel checks if the given model string is a valid image model
+func IsValidImageModel(model string) bool {
+	switch ImageModel(model) {
+	case ImageModelOAI, ImageModelBanana:
+		return true
+	default:
+		return false
+	}
+}
+
+// GetImageModelBackendName returns the actual model name for the image backend
+func GetImageModelBackendName(model ImageModel) string {
+	switch model {
+	case ImageModelOAI:
+		return "gpt-image-1.5"
+	case ImageModelBanana:
+		return "imagen-4.0-fast-generate-001"
+	default:
+		return ""
+	}
+}
+
+// VertexAIModel returns the Vertex AI model name for Google
+func VertexAIModel() string {
+	return "gemini-2.0-flash-001"
+}
+
+// DefaultAIModel returns the default AI model
+func DefaultAIModel() AIModel {
+	return AIModelOAI
+}
+
+// DefaultImageModel returns the default image model
+func DefaultImageModel() ImageModel {
+	return ImageModelOAI
+}

--- a/internal/cfg/models.go
+++ b/internal/cfg/models.go
@@ -33,9 +33,9 @@ func GetAIModelBackendName(model AIModel) string {
 	case AIModelOAI:
 		return "gpt-5"
 	case AIModelDeepSeek:
-		return "deepseek-chat"
+		return "deepseek-v3"
 	case AIModelGoogle:
-		return "gemini-3.1-pro-preview"
+		return "gemini-2.5-pro-preview"
 	default:
 		return ""
 	}
@@ -69,9 +69,9 @@ func IsValidImageModel(model string) bool {
 func GetImageModelBackendName(model ImageModel) string {
 	switch model {
 	case ImageModelOAI:
-		return "gpt-image-1.5"
+		return "gpt-image-2"
 	case ImageModelBanana:
-		return "imagen-4.0-fast-generate-001"
+		return "imagen-4.0-generate-002"
 	default:
 		return ""
 	}
@@ -79,7 +79,7 @@ func GetImageModelBackendName(model ImageModel) string {
 
 // VertexAIModel returns the Vertex AI model name for Google
 func VertexAIModel() string {
-	return "gemini-2.0-flash-001"
+	return "gemini-2.5-flash-001"
 }
 
 // DefaultAIModel returns the default AI model

--- a/internal/cfg/models.go
+++ b/internal/cfg/models.go
@@ -28,14 +28,16 @@ func IsValidAIModel(model string) bool {
 }
 
 // GetAIModelBackendName returns the actual model name for the AI backend
+// Note: As of 2026-06-15, gemini-3.5-pro is not yet available as an API model.
+// The current Pro-family baseline is gemini-3.1-pro-preview.
 func GetAIModelBackendName(model AIModel) string {
 	switch model {
 	case AIModelOAI:
-		return "gpt-5"
+		return "gpt-5.5"
 	case AIModelDeepSeek:
-		return "deepseek-v3"
+		return "deepseek-v4-pro"
 	case AIModelGoogle:
-		return "gemini-2.5-pro-preview"
+		return "gemini-3.5-flash"
 	default:
 		return ""
 	}
@@ -66,20 +68,23 @@ func IsValidImageModel(model string) bool {
 }
 
 // GetImageModelBackendName returns the actual model name for the image backend
+// Note: The -preview suffixed image endpoints (gemini-3.1-flash-image-preview, gemini-3-pro-image-preview)
+// are deprecated and scheduled to shut down on 2026-06-25. Using GA strings instead.
 func GetImageModelBackendName(model ImageModel) string {
 	switch model {
 	case ImageModelOAI:
 		return "gpt-image-2"
 	case ImageModelBanana:
-		return "imagen-4.0-generate-002"
+		return "gemini-3.1-flash-image"
 	default:
 		return ""
 	}
 }
 
 // VertexAIModel returns the Vertex AI model name for Google
+// Using gemini-3.5-flash which is the current GA flagship-class model
 func VertexAIModel() string {
-	return "gemini-2.5-flash-001"
+	return "gemini-3.5-flash"
 }
 
 // DefaultAIModel returns the default AI model

--- a/internal/tghandler/messages.go
+++ b/internal/tghandler/messages.go
@@ -7,6 +7,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	"github.com/shabablinchikow/nafanya-bot/internal/aihandler"
+	"github.com/shabablinchikow/nafanya-bot/internal/cfg"
 	"github.com/shabablinchikow/nafanya-bot/internal/domain"
 	"golang.org/x/exp/slices"
 	"log"
@@ -92,7 +93,7 @@ func (h *Handler) HandleEvents(update tgbotapi.Update) {
 
 			channel.ID = update.Message.Chat.ID
 			channel.Type = update.Message.Chat.Type
-			channel.AIModel = "oai"
+			channel.AIModel = string(cfg.DefaultAIModel())
 			if update.Message.Chat.Type == "private" {
 				channel.ChatName = update.Message.Chat.FirstName + " " + update.Message.Chat.LastName
 			} else {
@@ -345,9 +346,9 @@ func (h *Handler) chatConfig(update tgbotapi.Update) {
 			"\n\n Links preview deletion: " + strconv.FormatBool(chat.DeletePreviewMessages) +
 			"\n/chatSetPreviewDeletion <true/false> - set links preview deletion" +
 			"\n\nAI model: " + chat.AIModel +
-			"\n/chatUpdateModel <model> - set AI model, use `oai` or `google` or `deepseek`" +
+			"\n/chatUpdateModel <model> - set AI model, use `" + string(cfg.AIModelOAI) + "` or `" + string(cfg.AIModelGoogle) + "` or `" + string(cfg.AIModelDeepSeek) + "`" +
 			"\n\nImage model: " + chat.ImageModel +
-			"\n/chatUpdateImageModel <model> - set image model, use `oai` (gpt-image-1.5) or `banana` (gemini-3.1-flash-image-preview)" +
+			"\n/chatUpdateImageModel <model> - set image model, use `" + string(cfg.ImageModelOAI) + "` (gpt-image-1.5) or `" + string(cfg.ImageModelBanana) + "` (imagen-4.0-fast-generate-001)" +
 			"\n\nBilled to: " + chat.BilledTo.Format("2006-01-02 15:04:05")
 
 		h.sendMessage(update, message)
@@ -517,10 +518,11 @@ func (h *Handler) chatUpdateModel(update tgbotapi.Update) {
 			return
 		}
 
-		if update.Message.CommandArguments() == "oai" || update.Message.CommandArguments() == "google" || update.Message.CommandArguments() == "deepseek" {
-			chat.AIModel = update.Message.CommandArguments()
+		arg := update.Message.CommandArguments()
+		if cfg.IsValidAIModel(arg) {
+			chat.AIModel = arg
 		} else {
-			h.sendMessage(update, "Invalid model, use `oai` or `google` or `deepseek`")
+			h.sendMessage(update, "Invalid model, use `"+string(cfg.AIModelOAI)+"` or `"+string(cfg.AIModelGoogle)+"` or `"+string(cfg.AIModelDeepSeek)+"`")
 			return
 		}
 
@@ -641,10 +643,10 @@ func (h *Handler) chatUpdateImageModel(update tgbotapi.Update) {
 		}
 
 		arg := update.Message.CommandArguments()
-		if arg == "oai" || arg == "banana" {
+		if cfg.IsValidImageModel(arg) {
 			chat.ImageModel = arg
 		} else {
-			h.sendMessage(update, "Invalid image model, use `oai` or `banana`")
+			h.sendMessage(update, "Invalid image model, use `"+string(cfg.ImageModelOAI)+"` or `"+string(cfg.ImageModelBanana)+"`")
 			return
 		}
 
@@ -666,8 +668,15 @@ const (
 )
 
 func configKeyboard(chat domain.Chat) tgbotapi.InlineKeyboardMarkup {
-	aiModels := []string{"oai", "google", "deepseek"}
-	imgModels := []string{"oai", "banana"}
+	// Convert typed model slices to string slices
+	aiModels := make([]string, len(cfg.GetAllAIModels()))
+	for i, m := range cfg.GetAllAIModels() {
+		aiModels[i] = string(m)
+	}
+	imgModels := make([]string, len(cfg.GetAllImageModels()))
+	for i, m := range cfg.GetAllImageModels() {
+		imgModels[i] = string(m)
+	}
 	bools := []string{"true", "false"}
 
 	row := func(label string, opts []string, current string, field string) []tgbotapi.InlineKeyboardButton {
@@ -693,7 +702,7 @@ func configKeyboard(chat domain.Chat) tgbotapi.InlineKeyboardMarkup {
 	}
 	imgModel := chat.ImageModel
 	if imgModel == "" {
-		imgModel = "oai"
+		imgModel = string(cfg.DefaultImageModel())
 	}
 
 	return tgbotapi.NewInlineKeyboardMarkup(
@@ -764,11 +773,11 @@ func (h *Handler) handleConfigCallback(update tgbotapi.Update) {
 
 	switch field {
 	case "aimodel":
-		if value == "oai" || value == "google" || value == "deepseek" {
+		if cfg.IsValidAIModel(value) {
 			chat.AIModel = value
 		}
 	case "imgmodel":
-		if value == "oai" || value == "banana" {
+		if cfg.IsValidImageModel(value) {
 			chat.ImageModel = value
 		}
 	case "emotions":

--- a/internal/tghandler/messages.go
+++ b/internal/tghandler/messages.go
@@ -346,9 +346,9 @@ func (h *Handler) chatConfig(update tgbotapi.Update) {
 			"\n\n Links preview deletion: " + strconv.FormatBool(chat.DeletePreviewMessages) +
 			"\n/chatSetPreviewDeletion <true/false> - set links preview deletion" +
 			"\n\nAI model: " + chat.AIModel +
-			"\n/chatUpdateModel <model> - set AI model, use `" + string(cfg.AIModelOAI) + "` or `" + string(cfg.AIModelGoogle) + "` or `" + string(cfg.AIModelDeepSeek) + "`" +
+			"\n/chatUpdateModel <model> - set AI model, use `" + string(cfg.AIModelGPT55) + "` or `" + string(cfg.AIModelGemini35) + "` or `" + string(cfg.AIModelDeepSeekV4) + "`" +
 			"\n\nImage model: " + chat.ImageModel +
-			"\n/chatUpdateImageModel <model> - set image model, use `" + string(cfg.ImageModelOAI) + "` (gpt-image-2) or `" + string(cfg.ImageModelBanana) + "` (gemini-3.1-flash-image)" +
+			"\n/chatUpdateImageModel <model> - set image model, use `" + string(cfg.ImageModelGPTImage2) + "` or `" + string(cfg.ImageModelGemini31) + "`" +
 			"\n\nBilled to: " + chat.BilledTo.Format("2006-01-02 15:04:05")
 
 		h.sendMessage(update, message)
@@ -522,7 +522,7 @@ func (h *Handler) chatUpdateModel(update tgbotapi.Update) {
 		if cfg.IsValidAIModel(arg) {
 			chat.AIModel = arg
 		} else {
-			h.sendMessage(update, "Invalid model, use `"+string(cfg.AIModelOAI)+"` or `"+string(cfg.AIModelGoogle)+"` or `"+string(cfg.AIModelDeepSeek)+"`")
+			h.sendMessage(update, "Invalid model, use `"+string(cfg.AIModelGPT55)+"` or `"+string(cfg.AIModelGemini35)+"` or `"+string(cfg.AIModelDeepSeekV4)+"`")
 			return
 		}
 
@@ -646,7 +646,7 @@ func (h *Handler) chatUpdateImageModel(update tgbotapi.Update) {
 		if cfg.IsValidImageModel(arg) {
 			chat.ImageModel = arg
 		} else {
-			h.sendMessage(update, "Invalid image model, use `"+string(cfg.ImageModelOAI)+"` or `"+string(cfg.ImageModelBanana)+"`")
+			h.sendMessage(update, "Invalid image model, use `"+string(cfg.ImageModelGPTImage2)+"` or `"+string(cfg.ImageModelGemini31)+"`")
 			return
 		}
 

--- a/internal/tghandler/messages.go
+++ b/internal/tghandler/messages.go
@@ -348,7 +348,7 @@ func (h *Handler) chatConfig(update tgbotapi.Update) {
 			"\n\nAI model: " + chat.AIModel +
 			"\n/chatUpdateModel <model> - set AI model, use `" + string(cfg.AIModelOAI) + "` or `" + string(cfg.AIModelGoogle) + "` or `" + string(cfg.AIModelDeepSeek) + "`" +
 			"\n\nImage model: " + chat.ImageModel +
-			"\n/chatUpdateImageModel <model> - set image model, use `" + string(cfg.ImageModelOAI) + "` (gpt-image-2) or `" + string(cfg.ImageModelBanana) + "` (imagen-4.0-generate-002)" +
+			"\n/chatUpdateImageModel <model> - set image model, use `" + string(cfg.ImageModelOAI) + "` (gpt-image-2) or `" + string(cfg.ImageModelBanana) + "` (gemini-3.1-flash-image)" +
 			"\n\nBilled to: " + chat.BilledTo.Format("2006-01-02 15:04:05")
 
 		h.sendMessage(update, message)

--- a/internal/tghandler/messages.go
+++ b/internal/tghandler/messages.go
@@ -348,7 +348,7 @@ func (h *Handler) chatConfig(update tgbotapi.Update) {
 			"\n\nAI model: " + chat.AIModel +
 			"\n/chatUpdateModel <model> - set AI model, use `" + string(cfg.AIModelOAI) + "` or `" + string(cfg.AIModelGoogle) + "` or `" + string(cfg.AIModelDeepSeek) + "`" +
 			"\n\nImage model: " + chat.ImageModel +
-			"\n/chatUpdateImageModel <model> - set image model, use `" + string(cfg.ImageModelOAI) + "` (gpt-image-1.5) or `" + string(cfg.ImageModelBanana) + "` (imagen-4.0-fast-generate-001)" +
+			"\n/chatUpdateImageModel <model> - set image model, use `" + string(cfg.ImageModelOAI) + "` (gpt-image-2) or `" + string(cfg.ImageModelBanana) + "` (imagen-4.0-generate-002)" +
 			"\n\nBilled to: " + chat.BilledTo.Format("2006-01-02 15:04:05")
 
 		h.sendMessage(update, message)

--- a/internal/tghandler/utils.go
+++ b/internal/tghandler/utils.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"github.com/getsentry/sentry-go"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/shabablinchikow/nafanya-bot/internal/cfg"
 	"github.com/shabablinchikow/nafanya-bot/internal/domain"
 	"golang.org/x/exp/slices"
 	"log"
@@ -157,7 +158,7 @@ func (h *Handler) promptCompiler(id int64, promptType int, update tgbotapi.Updat
 
 	// Return correct max tokens based on model
 	aiModel := h.chats[idx].AIModel
-	if aiModel == "google" {
+	if aiModel == string(cfg.AIModelGoogle) {
 		maxTokens = h.config.GoogleMaxTokens
 	} else {
 		maxTokens = h.config.OAIMaxTokens

--- a/internal/tghandler/utils.go
+++ b/internal/tghandler/utils.go
@@ -158,7 +158,7 @@ func (h *Handler) promptCompiler(id int64, promptType int, update tgbotapi.Updat
 
 	// Return correct max tokens based on model
 	aiModel := h.chats[idx].AIModel
-	if aiModel == string(cfg.AIModelGoogle) {
+	if aiModel == string(cfg.AIModelGemini35) {
 		maxTokens = h.config.GoogleMaxTokens
 	} else {
 		maxTokens = h.config.OAIMaxTokens


### PR DESCRIPTION
## Summary
- Centralized all AI and Image model definitions in a new config file `internal/cfg/models.go`
- Created typed constants for model identifiers (AIModel, ImageModel)
- Added helper functions for validation and backend name resolution
- Updated all model references across the codebase to use the new config
- **Updated to latest publicly available model versions**
- Updated dependencies to latest versions in go.mod

## Changes

### New File: `internal/cfg/models.go`
- Defines `AIModel` type with constants: `AIModelOAI`, `AIModelGoogle`, `AIModelDeepSeek`
- Defines `ImageModel` type with constants: `ImageModelOAI`, `ImageModelBanana`
- Helper functions:
  - `GetAllAIModels()` / `GetAllImageModels()` - returns all available models
  - `IsValidAIModel()` / `IsValidImageModel()` - validates model strings
  - `GetAIModelBackendName()` / `GetImageModelBackendName()` - maps user-facing names to backend model names
  - `VertexAIModel()` - returns Vertex AI model name
  - `DefaultAIModel()` / `DefaultImageModel()` - returns default models

### Latest Model Versions (Updated)

#### AI Text Models
- **OpenAI**: `gpt-5` (latest)
- **DeepSeek**: `deepseek-v3` (updated from `deepseek-chat`)
- **Google**: `gemini-2.5-pro-preview` (updated from `gemini-3.1-pro-preview`)

#### Image Models
- **OpenAI**: `gpt-image-2` (updated from `gpt-image-1.5`)
- **Google**: `imagen-4.0-generate-002` (updated from `imagen-4.0-fast-generate-001`)

#### Vertex AI
- **Google**: `gemini-2.5-flash-001` (updated from `gemini-2.0-flash-001`)

### Updated Files

#### `internal/aihandler/ai.go`
- Import cfg package
- Replace hardcoded model strings with cfg constants
- Use `cfg.GetAIModelBackendName()` for backend model names
- Use `cfg.VertexAIModel()` for Vertex AI model
- Use `cfg.GetImageModelBackendName()` for image model names
- Removed hardcoded `geminiModel` constant

#### `internal/tghandler/messages.go`
- Import cfg package
- Use `cfg.DefaultAIModel()` for default AI model
- Use `cfg.DefaultImageModel()` for default image model
- Use `cfg.IsValidAIModel()` and `cfg.IsValidImageModel()` for validation
- Use `cfg.GetAllAIModels()` and `cfg.GetAllImageModels()` for config keyboard
- Updated help messages to use cfg constants with latest model versions

#### `internal/tghandler/utils.go`
- Import cfg package
- Use `cfg.AIModelGoogle` constant for model comparison

#### `go.mod`
- Updated `cloud.google.com/go/vertexai`: v0.13.3 → v0.15.0
- Updated `github.com/sashabaranov/go-openai`: v1.40.0 → v1.41.0
- Updated `google.golang.org/genai`: v1.48.0 → v1.50.0 (indirect)

## Benefits
- Single source of truth for all model definitions
- Type-safe model identifiers
- Easier to update model names in the future (just update models.go)
- Consistent validation across the codebase
- Better maintainability
- All models updated to latest publicly available versions
