### PR TITLE
fix: rename shadowed cfg variable in getPromptResponseGeminiDirect

### DIFF
--- a/internal/aihandler/ai.go
+++ b/internal/aihandler/ai.go
@@ -113,7 +113,7 @@ func extractYouTubeURLs(userInput string) ([]string, string) {
 
 func (h *Handler) getPromptResponseGeminiDirect(prompt string, userInput string, _ int) (string, error) {
 
-	cfg := &genaisdk.GenerateContentConfig{
+	geminiCfg := &genaisdk.GenerateContentConfig{
 		SystemInstruction: genaisdk.NewContentFromText(prompt, "user"),
 		SafetySettings: []*genaisdk.SafetySetting{
 			{Category: genaisdk.HarmCategoryHarassment, Threshold: genaisdk.HarmBlockThresholdBlockOnlyHigh},
@@ -137,7 +137,7 @@ func (h *Handler) getPromptResponseGeminiDirect(prompt string, userInput string,
 			context.Background(),
 			cfg.GetAIModelBackendName(cfg.AIModelGemini35),
 			contents,
-			cfg,
+			geminiCfg,
 		)
 		if err != nil {
 			log.Printf("Gemini attempt %d error: %v", i+1, err)


### PR DESCRIPTION
## Summary
Fixes a compilation error in PR #208 where a local variable named `cfg` was shadowing the imported `cfg` package.

## Issue
In `internal/aihandler/ai.go`, the function `getPromptResponseGeminiDirect` had a local variable:
```go
cfg := &genaisdk.GenerateContentConfig{...}
```

This shadowed the imported package `cfg` (from `github.com/shabablinchikow/nafanya-bot/internal/cfg`), causing compilation errors when trying to access:
- `cfg.GetAIModelBackendName(cfg.AIModelGemini35)`

The compiler interpreted `cfg` as the local variable of type `*genaisdk.GenerateContentConfig` instead of the imported package.

## Fix
Renamed the local variable from `cfg` to `geminiCfg` to avoid the naming conflict.

## Changes
- `internal/aihandler/ai.go`: Renamed local variable `cfg` → `geminiCfg` in `getPromptResponseGeminiDirect` function
- Updated the call to `h.geminiDirect.Models.GenerateContent` to use `geminiCfg` instead of `cfg`

## Testing
This fix allows the code to compile successfully.
