### PR TITLE
Change Instagram mirror from kksav.com to kkinstagram.com

### DIFF
--- a/internal/tghandler/messages.go
+++ b/internal/tghandler/messages.go
@@ -578,8 +578,8 @@ func (h *Handler) fixURLPreview(update tgbotapi.Update) {
 		}
 		if strings.Contains(url, "https://www.instagram.com") || strings.Contains(url, "https://instagram.com") {
 			h.sendAction(update, tgbotapi.ChatTyping)
-			url = strings.ReplaceAll(url, "https://www.instagram.com", "https://kksav.com")
-			url = strings.ReplaceAll(url, "https://instagram.com", "https://kksav.com")
+			url = strings.ReplaceAll(url, "https://www.instagram.com", "https://kkinstagram.com")
+			url = strings.ReplaceAll(url, "https://instagram.com", "https://kkinstagram.com")
 
 			message := buildFixedMessage(update.Message.From.UserName, url, caption)
 			h.sendMessage(update, message)


### PR DESCRIPTION
Updates the Instagram URL rewrite in `internal/tghandler/messages.go` to use `kkinstagram.com` instead of `kksav.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)